### PR TITLE
Fix: Update manual sections (fixes #37)

### DIFF
--- a/adapt-authoring.json
+++ b/adapt-authoring.json
@@ -3,7 +3,7 @@
   "documentation": {
     "enable": true,
     "manualPages": {
-      "using-mongodb.md": "basics"
+      "using-mongodb.md": "development"
     }
   }
 }


### PR DESCRIPTION
https://github.com/adapt-security/adapt-authoring-mongodb/issues/37

### Fix
* Updated the manual page section from "basics" to "development" in adapt-authoring.json