### PR TITLE
Update: Remove absorbed module dependencies

### DIFF
--- a/lib/MongoDBModule.js
+++ b/lib/MongoDBModule.js
@@ -12,7 +12,6 @@ import { parseObjectId } from './utils/parseObjectId.js'
 class MongoDBModule extends AbstractModule {
   /** @override */
   async init () {
-    await this.app.waitForModule('config')
     /**
      * Reference to the MongDB client
      * @type {external:MongoDBMongoClient}

--- a/lib/utils/findDuplicates.js
+++ b/lib/utils/findDuplicates.js
@@ -1,6 +1,6 @@
 /**
  * Finds documents with duplicate values for the given index fields.
- * @param {import('mongodb').Collection} collection The MongoDB collection to search
+ * @param {external:MongoDBCollection} collection The MongoDB collection to search
  * @param {String|Object} fieldOrSpec The index field spec (string key or object with field:direction pairs)
  * @returns {Promise<Array<{keyValue: Object, _ids: Array}>>} Array of duplicate groups
  */

--- a/package.json
+++ b/package.json
@@ -8,12 +8,11 @@
   "main": "index.js",
   "repository": "github:adapt-security/adapt-authoring-mongodb",
   "dependencies": {
-    "adapt-authoring-core": "^2.0.0",
+    "adapt-authoring-core": "^3.0.0",
     "mongodb": "^7.0.0"
   },
   "peerDependencies": {
-    "adapt-authoring-config": "^1.3.0",
-    "adapt-authoring-core": "^2.0.0",
+    "adapt-authoring-core": "^3.0.0",
     "adapt-authoring-jsonschema": "^1.2.2"
   },
   "devDependencies": {


### PR DESCRIPTION
### Update

- Remove `adapt-authoring-config` peerDependency (now a bootstrap library in core)
- Remove `waitForModule('config')` call — config is loaded before module init
- Bump `adapt-authoring-core` to `^3.0.0`